### PR TITLE
FIX Problem with query params

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
 - Added /v1/contextTypes to the URL Mappings of Orion.
 - Fix right plugins directory in pepProxy binary.
 - Fix accept content-type header with charset
-- Fix proxy query params
+- Fix proxy query params (#148)
+

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,6 @@
 - Added /v1/contextTypes to the URL Mappings of Orion.
 - Fix right plugins directory in pepProxy binary.
 - Fix accept content-type header with charset
-- Fix proxy query params (#148)
+- Fix proxy query params 
+- Fix some urls are not recognized with query params (#148)
 

--- a/lib/plugins/orionPlugin.js
+++ b/lib/plugins/orionPlugin.js
@@ -161,10 +161,10 @@ function inspectBody(req, res, callback) {
         callback(error, req, res);
     };
 
-    if (req.is('*/json')) {
+    if (req.is('application/json')) {
         logger.debug('Inspecting JSON body to discover action: \n%s\n\n', JSON.stringify(req.body, null, 4));
         inspectBodyJSON(req.body, actionHandler);
-    } else if (req.is('*/xml')) {
+    } else if (req.headers['content-type'] === 'application/xml' || req.headers['content-type'] === 'text/xml') {
         logger.debug('Inspecting XML body to discover action: \n%s\n\n', req.rawBody);
         inspectBodyXML(req.rawBody, actionHandler);
     } else {
@@ -186,7 +186,7 @@ function inspectUrl(req, res, callback) {
 
     for (var i = 0; i < identificationTable.length; i++) {
         if (req.method === identificationTable[i][0] &&
-            req.url.toLowerCase().match(identificationTable[i][1])) {
+            req.path.toLowerCase().match(identificationTable[i][1])) {
             req.action = identificationTable[i][2];
             callback(null, req, res);
             return;

--- a/lib/plugins/orionPlugin.js
+++ b/lib/plugins/orionPlugin.js
@@ -161,10 +161,10 @@ function inspectBody(req, res, callback) {
         callback(error, req, res);
     };
 
-    if (req.is('application/json')) {
+    if (req.is('*/json')) {
         logger.debug('Inspecting JSON body to discover action: \n%s\n\n', JSON.stringify(req.body, null, 4));
         inspectBodyJSON(req.body, actionHandler);
-    } else if (req.headers['content-type'] === 'application/xml' || req.headers['content-type'] === 'text/xml') {
+    } else if (req.is('*/xml')) {
         logger.debug('Inspecting XML body to discover action: \n%s\n\n', req.rawBody);
         inspectBodyXML(req.rawBody, actionHandler);
     } else {

--- a/test/unit/extract_cb_convenience_test.js
+++ b/test/unit/extract_cb_convenience_test.js
@@ -66,6 +66,7 @@ convenienceOperations = [
     ['POST', '/ngsi9/contextAvailabilitySubscriptions', 'subscribe-availability'],
     ['PUT', '/ngsi9/contextAvailabilitySubscriptions/TestedSubscriptionID002', 'subscribe-availability'],
     ['DELETE', '/ngsi9/contextAvailabilitySubscriptions/TestedSubscriptionID002', 'subscribe-availability'],
+
     /* "Classic" NGSI10 operations */
     ['GET', '/ngsi10/contextEntities/TestedEntityId002', 'read'],
     ['GET', '/ngsi10/contextEntities/type/TestedType01/id/TestedEntityId002', 'read'],
@@ -128,7 +129,15 @@ convenienceOperations = [
     ['GET', '/v1/contextSubscriptions', 'read'],
     ['GET', '/v1/contextSubscriptions/sub001', 'read'],
     ['GET', '/v1/contextTypes', 'read'],
-    ['GET', '/v1/contextTypes/typeOfEntity001', 'read']
+    ['GET', '/v1/contextTypes/typeOfEntity001', 'read'],
+
+    /* NGSI Operations with query params */
+    ['POST', '/v1/registry/contextAvailabilitySubscriptions?details=on&limit=15&offset=0 ',
+        'subscribe-availability'],
+    ['GET', '/v1/contextSubscriptions?details=on&limit=15&offset=0', 'read'],
+    ['POST', '/v1/registry/subscribeContextAvailability?details=on&limit=15&offset=0', 'subscribe-availability'],
+    ['POST', '/v1/registry/updateContextAvailabilitySubscription?details=on&limit=15&offset=0',
+        'subscribe-availability']
 ];
 
 describe('Extract Context Broker action from convenience operation requests', function() {


### PR DESCRIPTION
Use req.path instead of url for URL matching in Orion action identification.

Fixes Issue #148 