### PR TITLE
Bug/check empty headers

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -10,3 +10,4 @@
 - Check all the mandatory headers before processing the request (#165) (#110)
 - Group and redefine error codes.
 - Add execution mode without Access Control authorization for the PEP Proxy (#173)
+- Check the service and subservice headers for content (#176)

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -150,11 +150,10 @@ function sendRequest(req, res, next) {
  * @param {Function} next        Invokes the next middleware in the chain.
  */
 function checkMandatoryHeaders(req, res, next) {
-    var headerKeys = _.keys(req.headers),
-        missing = [];
+    var missing = [];
 
     for (var i = 0; i < mandatoryHeaders.length; i++) {
-        if (headerKeys.indexOf(mandatoryHeaders[i]) < 0) {
+        if (!req.headers[mandatoryHeaders[i]] || req.headers[mandatoryHeaders[i]].trim() === '') {
             missing.push(mandatoryHeaders[i]);
         }
     }

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -28,7 +28,6 @@ var config = require('../../config'),
     request = require('request'),
     logger = require('logops'),
     constants = require('../constants'),
-    _ = require('underscore'),
     mandatoryHeaders = [
         'fiware-service',
         'fiware-servicepath',


### PR DESCRIPTION
Check service and subervice headers for content and raise an error if they are empty.

Fix #176 