### PR TITLE
Task/check git status before releasing

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -12,3 +12,4 @@
 - Add execution mode without Access Control authorization for the PEP Proxy (#173)
 - Check the service and subservice headers for content (#176)
 - Fix the Keystone user authentication error was raised as a connection one (#174)
+- Add a guard in the release script to abort if there are unstagged git changes (#181)

--- a/scripts/build/release.sh
+++ b/scripts/build/release.sh
@@ -53,7 +53,18 @@ EOF
   exit 1
 }
 
+#
+# Check git status and abort if it is dirty
+#
+function checkGitStatus() {
+  git status |grep "Changes not staged for commit" > /dev/null
+  RESULT=$?
 
+  if [ $RESULT = 0 ]; then
+    echo "There are unstaged changes in your git workspace. Clean them before proceeding with the release"
+    exit 0
+  fi
+}
 
 #
 # Chewcking command line parameters
@@ -81,6 +92,7 @@ export PEP_RELEASE=$2
 DATE=$(LANG=C date +"%a %b %d %Y")
 export dateLine="$DATE Daniel Moran <daniel.moranjimenez@telefonica.com> ${NEW_VERSION}"
 
+checkGitStatus
 
 # Modify rpm/SPECS/pepProxy.spec only when step to a non-devel release
 if [ "$PEP_RELEASE" != "dev" ]


### PR DESCRIPTION
Add a guard against unstagged changes in git for the release script. 

Fix #181 