### PR TITLE
Task/iotagents plugin

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - FIX Service not found for tokens coming from a trust.
 - FIX XAuth Token not checked if validation is off (#197)
+- ADD Tests for the IOTAgent plugin (using the generic REST plugin).

--- a/README.md
+++ b/README.md
@@ -675,6 +675,18 @@ config.middlewares = {
    ]
 };
 ```
+In order to add more expression power to the authorization rules created in the Access Control component, the Generic REST Plugin adds a new element to the FRN: the URL of the resource is appended to the existing elements in the FRN.
+
+### URL Table Generic middleware
+For applications that require a mapping between URLs and Method to actions when the REST Middleware is not enough, a plugin generator based on tables is provided. In order to use this plugin, create a new plugin file and import the `./urlTablePlugin` module. This module contains just one function, `extractAction`, that takes a mapping table and generates a middleware function that extract the action of a request based on it. 
+
+The mapping table has to have one row for each action to check indicating:
+* Request **Method**
+* **URL** pattern (using regular expressions)
+* **Action** name
+Whenever a request arrives to the plugin with the selected method and a URL that matches the URL expression, the action will be assigned to the request.
+
+An example of use of the `urlTablePlugin` can be found in the Perseo plugin.
 
 ## <a name="licence"/> License
 

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -96,6 +96,12 @@ function generateFRN(req, res, next) {
         frn += ':';
     }
 
+    if (req.resourceUrl) {
+        frn += req.resourceUrl + ':';
+    } else {
+        frn += ':';
+    }
+
     if (req.entityType) {
         frn += req.entityType;
     } else {

--- a/lib/plugins/perseoPlugin.js
+++ b/lib/plugins/perseoPlugin.js
@@ -23,8 +23,7 @@
 
 'use strict';
 
-var logger = require('logops'),
-    errors = require('../errors');
+var urlTablePlugin = require('./urlTablePlugin');
 
 /**
  * Perseo operation identification table. Each row of the table contains an operation with three fields:
@@ -46,25 +45,5 @@ var perseoOperations = [
     ['PUT', /\/m2m\/vrules\/.*/, 'writeRule']
 ];
 
-/**
- * Middleware to calculate what Perseo action has been received based on the path and the request payload.
- *
- * @param {Object} req           Incoming request.
- * @param {Object} res           Outgoing response.
- */
-function extractAction(req, res, callback) {
-    logger.debug('Extracting action from URL [%s] and method [%s]', req.url, req.method);
 
-    for (var i = 0; i < perseoOperations.length; i++) {
-        if (req.method === perseoOperations[i][0] &&
-            req.path.match(perseoOperations[i][1])) {
-            req.action = perseoOperations[i][2];
-            callback(null, req, res);
-            return;
-        }
-    }
-
-    callback(new errors.ActionNotFound(), req, res);
-}
-
-exports.extractAction = extractAction;
+exports.extractAction = urlTablePlugin.extractAction(perseoOperations);

--- a/lib/plugins/restPlugin.js
+++ b/lib/plugins/restPlugin.js
@@ -51,6 +51,8 @@ function extractAction(req, res, next) {
             req.action = null;
     }
 
+    req.resourceUrl = req.url;
+
     next(null, req, res);
 }
 

--- a/lib/plugins/urlTablePlugin.js
+++ b/lib/plugins/urlTablePlugin.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-orion-pep
+ *
+ * fiware-orion-pep is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-orion-pep is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-orion-pep.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ */
+
+'use strict';
+
+var logger = require('logops'),
+    errors = require('../errors');
+
+/**
+ * Generates a middleware that extracts the action from the request's URL and method using the table passed as a
+ * parameter. Each row in the table should contain three elements:
+ * - Method
+ * - Regular expression to match the URL
+ * - Name of the action
+ *
+ * If URL matches the regular expression and the request has the indicated method, the designated action is included
+ * in the request object 'action' attribute.
+ *
+ * @param {Array} operations        Array of operations to map URLs to actions.
+ * @return {Function}               Middleware that extracts the action from the URL and method.
+ */
+function extractAction(operations) {
+    return function(req, res, callback) {
+        logger.debug('Extracting action from URL [%s] and method [%s]', req.url, req.method);
+
+        for (var i = 0; i < operations.length; i++) {
+            if (req.method === operations[i][0] &&
+                req.path.match(operations[i][1])) {
+                req.action = operations[i][2];
+                callback(null, req, res);
+                return;
+            }
+        }
+
+        callback(new errors.ActionNotFound(), req, res);
+    };
+}
+
+exports.extractAction = extractAction;

--- a/test/unit/iotagent_plugin-test.js
+++ b/test/unit/iotagent_plugin-test.js
@@ -35,8 +35,6 @@ var serverMocks = require('../tools/serverMocks'),
 
 describe('IOT Agent Plugin tests', function() {
     var proxy,
-        mockTarget,
-        mockTargetApp,
         mockServer,
         mockApp,
         mockAccess,
@@ -54,17 +52,7 @@ describe('IOT Agent Plugin tests', function() {
             ['GET', '/iot/agents/defaultIoTAgent/services', 'read'],
             ['PUT', '/iot/agents/defaultIoTAgent/services', 'update'],
             ['DELETE', '/iot/agents/defaultIoTAgent/services', 'delete']
-        ],
-        authenticationMechanism = {
-            module: 'keystone',
-            path: '/v3/role_assignments',
-            authPath: '/v3/auth/tokens',
-            rolesFile: './test/keystoneResponses/rolesOfUser.json',
-            authenticationResponse: './test/keystoneResponses/authorize.json',
-            headers: [
-            ],
-            authMock: serverMocks.mockKeystone
-        };
+        ];
 
     function apiCase(particularCase) {
         var options = {

--- a/test/unit/iotagent_plugin-test.js
+++ b/test/unit/iotagent_plugin-test.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-orion-pep
+ *
+ * fiware-orion-pep is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-orion-pep is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-orion-pep.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[daniel.moranjimenez@telefonica.com]
+ */
+
+'use strict';
+
+var serverMocks = require('../tools/serverMocks'),
+    proxyLib = require('../../lib/fiware-orion-pep'),
+    restPlugin = require('../../lib/plugins/restPlugin'),
+    keystonePlugin = require('../../lib/services/keystoneAuth'),
+    config = require('../../config'),
+    utils = require('../tools/utils'),
+    should = require('should'),
+    async = require('async'),
+    request = require('request');
+
+describe('IOT Agent Plugin tests', function() {
+    var proxy,
+        mockTarget,
+        mockTargetApp,
+        mockServer,
+        mockApp,
+        mockAccess,
+        mockAccessApp,
+        mockOAuth,
+        mockOAuthApp,
+        apiCases = [
+            ['POST', '/iot/devices', 'create'],
+            ['GET', '/iot/devices', 'read'],
+            ['GET', '/iot/devices/aDevice', 'read'],
+            ['DELETE', '/iot/devices/aDevice', 'delete'],
+            ['PUT', '/iot/devices/aDevice', 'update'],
+
+            ['POST', '/iot/agents/defaultIoTAgent/services', 'create'],
+            ['GET', '/iot/agents/defaultIoTAgent/services', 'read'],
+            ['PUT', '/iot/agents/defaultIoTAgent/services', 'update'],
+            ['DELETE', '/iot/agents/defaultIoTAgent/services', 'delete']
+        ],
+        authenticationMechanism = {
+            module: 'keystone',
+            path: '/v3/role_assignments',
+            authPath: '/v3/auth/tokens',
+            rolesFile: './test/keystoneResponses/rolesOfUser.json',
+            authenticationResponse: './test/keystoneResponses/authorize.json',
+            headers: [
+            ],
+            authMock: serverMocks.mockKeystone
+        };
+
+    function apiCase(particularCase) {
+        var options = {
+            uri: 'http://localhost:' + config.resource.proxy.port + particularCase[1],
+            method: particularCase[0],
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Fiware-Service': 'SmartValencia',
+                'fiware-servicepath': 'Electricidad',
+                'X-Auth-Token': 'UAidNA9uQJiIVYSCg0IQ8Q'
+            },
+            json: {}
+        };
+
+        describe('When  a ' + particularCase[0] + ' request arrives to the ' +
+        particularCase[1] + ' url of the IOT Agent through the PEP Proxy', function() {
+
+            beforeEach(function(done) {
+                config.middlewares.require = 'lib/services/restPlugin';
+                config.middlewares.function = [
+                    'extractAction'
+                ];
+
+                keystonePlugin.cleanCache();
+
+                proxyLib.start(function(error, proxyObj) {
+                    proxy = proxyObj;
+
+                    proxy.middlewares.push(restPlugin.extractAction);
+
+                    serverMocks.start(config.resource.original.port, function(error, server, app) {
+                        mockServer = server;
+                        mockApp = app;
+
+                        serverMocks.start(config.access.port, function(error, serverAccess, appAccess) {
+                            mockAccess = serverAccess;
+                            mockAccessApp = appAccess;
+                            mockAccessApp.handler = function(req, res) {
+                                res.set('Content-Type', 'application/xml');
+                                res.send(utils.readExampleFile('./test/accessControlResponses/permitResponse.xml',
+                                    true));
+                            };
+
+                            serverMocks.start(config.authentication.options.port, function(error, serverAuth, appAuth) {
+                                mockOAuth = serverAuth;
+                                mockOAuthApp = appAuth;
+
+                                mockOAuthApp.handler = function(req, res) {
+                                    res.json(200,
+                                        utils.readExampleFile('./test/authorizationResponses/rolesOfUser.json'));
+                                };
+
+                                async.series([
+                                    async.apply(serverMocks.mockPath, '/user', mockOAuthApp),
+                                    async.apply(serverMocks.mockPath, '/validate', mockAccessApp),
+                                    async.apply(serverMocks.mockPath, '/generalResource', mockAccessApp)
+                                ], done);
+                            });
+                        });
+                    });
+                });
+            });
+
+            it('should mark the action as "' + particularCase[2] + '"', function(done) {
+                var extractionExecuted = false;
+
+                var testExtraction = function(req, res, callback) {
+                    should.exist(req.action);
+                    req.action.should.equal(particularCase[2]);
+                    extractionExecuted = true;
+                    callback(null, req, res);
+                };
+
+                proxy.middlewares.push(testExtraction);
+
+                request(options, function(error, response, body) {
+                    extractionExecuted.should.equal(true);
+                    done();
+                });
+            });
+
+            afterEach(function(done) {
+                proxyLib.stop(proxy, function(error) {
+                    serverMocks.stop(mockServer, function() {
+                        serverMocks.stop(mockAccess, function() {
+                            serverMocks.stop(mockOAuth, done);
+                        });
+                    });
+                });
+            });
+        });
+    }
+
+    apiCases.forEach(apiCase);
+});


### PR DESCRIPTION
Add IOTAgent plugin tests. There was no specific IOTAgent plugin created, as the generic REST one fit perfectly. 

Also, refactor Perseo's plugin to create a generic "URL-Table plugin" that checks an assignment from (method, URL) to action.