### PR TITLE
Task/print incoming request headers

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - FIX Wrong JSON payload generates wrong type of error (#194)
 - ADD Tests for the IOTAgent plugin (using the generic REST plugin).
 - ADD Remove slow operations in debug logs (#48).
+- ADD Tracing debug mode (#64).

--- a/lib/fiware-orion-pep.js
+++ b/lib/fiware-orion-pep.js
@@ -126,6 +126,21 @@ function createDynamicMiddlewareExecutor(proxyObj) {
     };
 }
 
+function traceRequest(req, res, next) {
+    logger.debug('Request for path [%s] from [%s]', req.path, req.get('host'));
+    logger.debug('Headers:\n%j\n', req.headers);
+
+    if (req.headers['content-type'] === 'application/json') {
+        logger.debug('Body:\n\n%s\n\n', JSON.stringify(req.body, null, 4));
+    } else if (req.headers['content-type'] === 'application/xml') {
+        logger.debug('Body:\n\n%s\n\n', req.rawBody);
+    } else {
+        logger.debug('Unrecognized body type', req.headers['content-type']);
+    }
+
+    next();
+}
+
 /**
  * Initializes the proxy server. It fills the proxyObj with information about the started proxy and passes it along.
  *
@@ -140,6 +155,10 @@ function initializeProxy(proxyObj, callback) {
     proxyObj.proxy.use(xmlRawBody);
     proxyObj.proxy.use(express.urlencoded());
     proxyObj.proxy.use(domainMiddleware);
+
+    if (config.logLevel && config.logLevel === 'DEBUG') {
+        proxyObj.proxy.use(traceRequest);
+    }
 
     if (!config.access.disable || config.authentication.checkHeaders) {
         proxyObj.proxy.use(proxyMiddleware.checkMandatoryHeaders);

--- a/lib/fiware-orion-pep.js
+++ b/lib/fiware-orion-pep.js
@@ -126,6 +126,16 @@ function createDynamicMiddlewareExecutor(proxyObj) {
     };
 }
 
+/**
+ * Trace the incoming request data to the log. It prints headers and body, using an indentation of 4 spaces. NOTE:
+ * in the case of this middleware there is no performance penalty for using the JSON.stringify() function instead of
+ * the '%j' classifier in the log pattern, as this middleware will be executed just in the case where the proxy has
+ * been started in debugging mode (so the indentation has been kept in this log entries to ease the debugging tasks).
+ *
+ * @param {Object} req           Incoming request.
+ * @param {Object} res           Outgoing response.
+ * @param {Function} next        Call to the next error handler in the chain.
+ */
 function traceRequest(req, res, next) {
     logger.debug('Request for path [%s] from [%s]', req.path, req.get('host'));
     logger.debug('Headers:\n%j\n', req.headers);


### PR DESCRIPTION
Address issue #64 

Adds a reques trace in debug mode to print the headers and body or the requesxt.