### PR TITLE
ADD Environment variable for admin port

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Some of the configuration values for the attributes above mentioned can be overr
 | Environment variable | Configuration attribute             |
 |:-------------------- |:----------------------------------- |
 | PROXY_PORT           | config.resource.proxy.port          | 
+| ADMIN_PORT           | config.resource.proxy.adminPort     | 
 | TARGET_HOST          | config.resource.original.host       |
 | TARGET_PORT          | config.resource.original.port       |
 | LOG_LEVEL            | config.logLevel                     |

--- a/bin/pepProxy
+++ b/bin/pepProxy
@@ -44,6 +44,7 @@ function loadConfiguration() {
         'ACCESS_HOST',
         'ACCESS_PORT',
         'ACCESS_PROTOCOL',
+        'ADMIN_PORT',
         'AUTHENTICATION_HOST',
         'AUTHENTICATION_PORT',
         'AUTHENTICATION_PROTOCOL',
@@ -65,6 +66,9 @@ function loadConfiguration() {
     }
     if (process.env.TARGET_PORT) {
         config.resource.original.port = process.env.TARGET_PORT;
+    }
+    if (process.env.ADMIN_PORT) {
+        config.resource.proxy.adminPort = process.env.ADMIN_PORT;
     }
     if (process.env.LOG_LEVEL) {
         config.logLevel = process.env.LOG_LEVEL;


### PR DESCRIPTION
Add an environment variable, ADMIN_PORT, to configure the administration port.

Fixes #210